### PR TITLE
プロモーションコードの機能を追加

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -8,8 +8,6 @@ class CartsController < ApplicationController
     if promo_code.present? && !promo_code.is_used
       @cart.promotion_code = promo_code
       @cart.save
-      Rails.logger.info "Cart: #{@cart.inspect}"
-      Rails.logger.info "Promotion code: #{promo_code.inspect}"
       redirect_to cart_path, notice: 'プロモーションコードが適用されました。'
     else
       redirect_to cart_path, alert: '無効なプロモーションコードです。'

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -8,10 +8,11 @@ class CartsController < ApplicationController
     if promo_code.present? && !promo_code.is_used
       @cart.promotion_code = promo_code
       @cart.save
+      Rails.logger.info "Cart: #{@cart.inspect}"
+      Rails.logger.info "Promotion code: #{promo_code.inspect}"
       redirect_to cart_path, notice: 'プロモーションコードが適用されました。'
     else
       redirect_to cart_path, alert: '無効なプロモーションコードです。'
     end
   end
-
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -5,12 +5,16 @@ class CartsController < ApplicationController
 
   def apply_promo_code
     promo_code = PromotionCode.find_by(code: params[:code])
-    if promo_code.present? && !promo_code.is_used
-      @cart.promotion_code = promo_code
-      @cart.save
+    if promo_code.blank? || promo_code.is_used
+      redirect_to cart_path, alert: '無効なプロモーションコードです。'
+      return
+    end
+
+    @cart.promotion_code = promo_code
+    if @cart.save
       redirect_to cart_path, notice: 'プロモーションコードが適用されました。'
     else
-      redirect_to cart_path, alert: '無効なプロモーションコードです。'
+      redirect_to cart_path, alert: 'プロモーションコードの適用に失敗しました。再度お試しください。'
     end
   end
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -2,4 +2,16 @@
 
 class CartsController < ApplicationController
   def show; end
+
+  def apply_promo_code
+    promo_code = PromotionCode.find_by(code: params[:code])
+    if promo_code.present? && !promo_code.is_used
+      @cart.promotion_code = promo_code
+      @cart.save
+      redirect_to cart_path, notice: 'プロモーションコードが適用されました。'
+    else
+      redirect_to cart_path, alert: '無効なプロモーションコードです。'
+    end
+  end
+
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -13,15 +13,7 @@ class OrdersController < ApplicationController
       redirect_to cart_path, alert: '選択されたプロモーションコードは既に使用されています。'
       return
     end
-    Order.transaction do # start トランザクション処理
-      if @cart.cart_items.present?
-        @order.create_order_with_items(@cart)
-        session[:cart_id] = nil
-        redirect_to root_path, notice: 'ご購入ありがとうございました。'
-      else
-        redirect_to cart_path, notice: '商品をカートに入れてください。'
-      end
-    end
+    process_order
   rescue ActiveRecord::RecordInvalid => e
     redirect_to cart_path, notice: e.message
   end
@@ -44,8 +36,22 @@ class OrdersController < ApplicationController
     end
   end
 
+  # プロモーションコードが既に使用されているかどうかを判定するメソッド
   def promo_code_already_used?
     promo_code = @cart.promotion_code
     promo_code.present? && promo_code.is_used
+  end
+
+  # オーダー処理をメソッドに切り出す
+  def process_order
+    Order.transaction do # start トランザクション処理
+      if @cart.cart_items.present?
+        @order.create_order_with_items(@cart)
+        session[:cart_id] = nil
+        redirect_to root_path, notice: 'ご購入ありがとうございました。'
+      else
+        redirect_to cart_path, notice: '商品をカートに入れてください。'
+      end
+    end
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -9,6 +9,10 @@ class OrdersController < ApplicationController
 
   def create
     @order = Order.new(order_params)
+    if promo_code_already_used?
+      redirect_to cart_path, alert: '選択されたプロモーションコードは既に使用されています。'
+      return
+    end
     Order.transaction do # start トランザクション処理
       if @cart.cart_items.present?
         @order.create_order_with_items(@cart)
@@ -38,5 +42,10 @@ class OrdersController < ApplicationController
     authenticate_or_request_with_http_basic do |username, password|
       username == 'admin' && password == 'pw'
     end
+  end
+
+  def promo_code_already_used?
+    promo_code = @cart.promotion_code
+    promo_code.present? && promo_code.is_used
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -4,4 +4,5 @@ class Cart < ApplicationRecord
   has_many :cart_items, dependent: :destroy
   has_many :products, through: :cart_items
   has_one :order, dependent: :nullify
+  belongs_to :promotion_code, optional: true
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -17,7 +17,15 @@ class Order < ApplicationRecord
   # オーダー作成とメール送信
   def create_order_with_items(cart)
     self.order_items = Order.order_items_from_cart(cart)
+    use_promotion_code(cart)
     save!
     OrderMailer.order_confirmation(self).deliver_now
   end
+
+  # プロモーションコードの使用
+  def use_promotion_code(cart)
+    self.discount = cart.promotion_code&.discount || 0
+    cart.promotion_code&.update(is_used: true)
+  end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -27,5 +27,4 @@ class Order < ApplicationRecord
     self.discount = cart.promotion_code&.discount || 0
     cart.promotion_code&.update(is_used: true)
   end
-
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -16,10 +16,15 @@ class Order < ApplicationRecord
 
   # オーダー作成とメール送信
   def create_order_with_items(cart)
-    self.order_items = Order.order_items_from_cart(cart)
-    use_promotion_code(cart)
-    save!
-    OrderMailer.order_confirmation(self).deliver_now
+    return false if cart.cart_items.blank?
+
+    Order.transaction do
+      self.order_items = Order.order_items_from_cart(cart)
+      use_promotion_code(cart)
+      save!
+      OrderMailer.order_confirmation(self).deliver_now
+    end
+    true
   end
 
   # プロモーションコードの使用

--- a/app/models/promotion_code.rb
+++ b/app/models/promotion_code.rb
@@ -1,0 +1,6 @@
+class PromotionCode < ApplicationRecord
+  has_one :cart
+  validates :code, presence: true, uniqueness: true, length: { is: 7 }
+  validates :discount, presence: true, numericality: { greater_than_or_equal_to: 100, less_than_or_equal_to: 1000 }
+  validates :is_used, inclusion: { in: [true, false] }
+end

--- a/app/models/promotion_code.rb
+++ b/app/models/promotion_code.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class PromotionCode < ApplicationRecord
-  has_one :cart
+  has_one :cart, dependent: :nullify
   validates :code, presence: true, uniqueness: true, length: { is: 7 }
   validates :discount, presence: true, numericality: { greater_than_or_equal_to: 100, less_than_or_equal_to: 1000 }
   validates :is_used, inclusion: { in: [true, false] }

--- a/app/views/carts/_form.html.erb
+++ b/app/views/carts/_form.html.erb
@@ -1,0 +1,101 @@
+<div class="col-md-7 col-lg-8">
+  <h4 class="mb-3">請求先住所</h4>
+  <%= form_with(url: orders_path, method: :post, class: "needs-validation", novalidate: true) do |form| %>
+  <%= form.hidden_field :cart_id, value: @cart.id %>
+
+
+    <div class="row g-3">
+      <div class="col-sm-6">
+        <%= form.label :family_name, "姓*", class: 'form-label' %>
+        <%= form.text_field :family_name, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Valid first name is required.
+        </div>
+      </div>
+
+      <div class="col-sm-6">
+        <%= form.label :given_name, "名*", class: 'form-label' %>
+        <%= form.text_field :given_name, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Valid last name is required.
+        </div>
+      </div>
+
+      <div class="col-12">
+        <%= form.label :email, "メールアドレス*", class: 'form-label' %>
+        <%= form.email_field :email, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Please enter a valid email address for shipping updates.
+        </div>
+      </div>
+
+      <div class="col-md-3">
+        <%= form.label :postal_code, "郵便番号*", class: 'form-label' %>
+        <%= form.text_field :postal_code, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Zip code required.
+        </div>
+      </div>
+
+      <div class="col-12">
+        <%= form.label :address1, "住所 1*", class: 'form-label' %>
+        <%= form.text_field :address1, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Please enter your shipping address.
+        </div>
+      </div>
+
+      <div class="col-12">
+        <%= form.label :address2, "住所 2 <span class='text-body-secondary'>(任意)</span>".html_safe, class: 'form-label' %>
+        <%= form.text_field :address2, class: 'form-control' %>
+      </div>
+    </div>
+
+    <hr class="my-4">
+
+    <h4 class="mb-3">支払い情報</h4>
+
+    <div class="my-3">
+      <div class="form-check">
+        <input id="credit" name="paymentMethod" type="radio" class="form-check-input" checked required>
+        <label class="form-check-label" for="credit">クレジットカード</label>
+      </div>
+    </div>
+
+    <div class="row gy-3">
+      <div class="col-md-6">
+        <%= form.label :card_name, "カード名義", class: 'form-label' %>
+        <%= form.text_field :card_name, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Name on card is required
+        </div>
+      </div>
+      <div class="col-md-6">
+        <%= form.label :card_number, "カード番号", class: 'form-label' %>
+        <%= form.text_field :card_number, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Credit card number is required
+        </div>
+      </div>
+      <div class="col-md-3">
+        <%= form.label :card_expire, "期限", class: 'form-label' %>
+        <%= form.text_field :card_expire, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Expiration date required
+        </div>
+      </div>
+
+      <div class="col-md-3">
+        <%= form.label :card_cvv, "CVV", class: 'form-label' %>
+        <%= form.text_field :card_cvv, class: 'form-control', required: true %>
+        <div class="invalid-feedback">
+          Security code required
+        </div>
+      </div>
+    </div>
+    <hr class="my-4">
+    <%= form.submit "購入する", class: "w-100 btn btn-primary btn-lg" %>
+  <% end %>
+
+
+</div>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -23,126 +23,29 @@
         </li>
       <% end %>
       <%# 割引コード %>
-      <%# <li class="list-group-item d-flex justify-content-between lh-sm">
-        <div>
-          <h6 class="my-0">Third item</h6>
-          <small class="text-body-secondary">Brief description</small>
-        </div>
-        <span class="text-body-secondary">$5</span>
-      </li> %>
+      <% if @cart.promotion_code.present? %>
+        <li class="list-group-item d-flex justify-content-between bg-body-tertiary">
+          <div class="text-success">
+            <h6 class="my-0">Promo code</h6>
+            <small><%= @cart.promotion_code.code %></small>
+          </div>
+          <span class="text-success">−<%= number_to_currency(@cart.promotion_code.discount) %></span>
+        </li>
+      <% end %>
+
       <li class="list-group-item d-flex justify-content-between">
         <span>合計</span>
-        <strong><%= "#{number_to_currency(total_price)}" %></strong>
+        <strong><%= "#{number_to_currency(total_price - (@cart.promotion_code&.discount || 0))}" %></strong>
       </li>
     </ul>
 
-    <form class="card p-2">
+    <%= form_with url: apply_promo_code_path, method: :post, class: "card p-2" do |f| %>
       <div class="input-group">
-        <input type="text" class="form-control" placeholder="Promo code">
-        <button type="submit" class="btn btn-secondary">Redeem</button>
+        <%= f.text_field :code, class: "form-control", placeholder: "Promo code" %>
+        <%= f.submit "適用", class: "btn btn-secondary" %>
       </div>
-    </form>
-  </div>
-
-  <div class="col-md-7 col-lg-8">
-    <h4 class="mb-3">請求先住所</h4>
-    <%= form_with(url: orders_path, method: :post, class: "needs-validation", novalidate: true) do |form| %>
-    <%= form.hidden_field :cart_id, value: @cart.id %>
-
-
-      <div class="row g-3">
-        <div class="col-sm-6">
-          <%= form.label :family_name, "姓*", class: 'form-label' %>
-          <%= form.text_field :family_name, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Valid first name is required.
-          </div>
-        </div>
-
-        <div class="col-sm-6">
-          <%= form.label :given_name, "名*", class: 'form-label' %>
-          <%= form.text_field :given_name, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Valid last name is required.
-          </div>
-        </div>
-
-        <div class="col-12">
-          <%= form.label :email, "メールアドレス*", class: 'form-label' %>
-          <%= form.email_field :email, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Please enter a valid email address for shipping updates.
-          </div>
-        </div>
-
-        <div class="col-md-3">
-          <%= form.label :postal_code, "郵便番号*", class: 'form-label' %>
-          <%= form.text_field :postal_code, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Zip code required.
-          </div>
-        </div>
-
-        <div class="col-12">
-          <%= form.label :address1, "住所 1*", class: 'form-label' %>
-          <%= form.text_field :address1, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Please enter your shipping address.
-          </div>
-        </div>
-
-        <div class="col-12">
-          <%= form.label :address2, "住所 2 <span class='text-body-secondary'>(任意)</span>".html_safe, class: 'form-label' %>
-          <%= form.text_field :address2, class: 'form-control' %>
-        </div>
-      </div>
-
-      <hr class="my-4">
-
-      <h4 class="mb-3">支払い情報</h4>
-
-      <div class="my-3">
-        <div class="form-check">
-          <input id="credit" name="paymentMethod" type="radio" class="form-check-input" checked required>
-          <label class="form-check-label" for="credit">クレジットカード</label>
-        </div>
-      </div>
-
-      <div class="row gy-3">
-        <div class="col-md-6">
-          <%= form.label :card_name, "カード名義", class: 'form-label' %>
-          <%= form.text_field :card_name, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Name on card is required
-          </div>
-        </div>
-        <div class="col-md-6">
-          <%= form.label :card_number, "カード番号", class: 'form-label' %>
-          <%= form.text_field :card_number, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Credit card number is required
-          </div>
-        </div>
-        <div class="col-md-3">
-          <%= form.label :card_expire, "期限", class: 'form-label' %>
-          <%= form.text_field :card_expire, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Expiration date required
-          </div>
-        </div>
-
-        <div class="col-md-3">
-          <%= form.label :card_cvv, "CVV", class: 'form-label' %>
-          <%= form.text_field :card_cvv, class: 'form-control', required: true %>
-          <div class="invalid-feedback">
-            Security code required
-          </div>
-        </div>
-      </div>
-      <hr class="my-4">
-      <%= form.submit "購入する", class: "w-100 btn btn-primary btn-lg" %>
     <% end %>
-
-
   </div>
+
+  <%= render partial: 'carts/form' %>
 </div>

--- a/app/views/order_mailer/order_confirmation.text.erb
+++ b/app/views/order_mailer/order_confirmation.text.erb
@@ -25,7 +25,11 @@
 小計: <%= item_total %> 円
 <% end %>
 
-合計金額: <%= total_price %> 円
+<% if @order.discount > 0 %>
+割引額: <%= @order.discount %> 円
+<% end %>
+
+合計金額: <%= total_price - @order.discount %> 円
 
 ご不明な点がございましたら、お気軽にお問い合わせください。
 それでは、商品のお届けまで今しばらくお待ちください。

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -37,7 +37,11 @@
       <% end %>
     </tbody>
   </table>
-  <p><strong>合計金額：</strong><%= number_to_currency(total_price) %></p>
+  <% if @order.discount > 0 %>
+    <p><strong>割引額：</strong><%= number_to_currency(@order.discount) %></p>
+  <% end %>
+  <p><strong>合計金額：</strong><%= number_to_currency(total_price - @order.discount) %></p>
+
 
   <%= link_to '購入明細一覧に戻る', orders_path, class: 'btn btn-primary mt-5' %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
   resource :cart, only:  %i[show]
   resources :cart_items, only: %i[create destroy]
   resources :orders, only: %i[index create show]
+  post 'apply_promo_code', to: 'carts#apply_promo_code'
+
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
 end

--- a/db/migrate/20230501152912_create_promotion_codes.rb
+++ b/db/migrate/20230501152912_create_promotion_codes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePromotionCodes < ActiveRecord::Migration[7.0]
   def change
     create_table :promotion_codes do |t|

--- a/db/migrate/20230501152912_create_promotion_codes.rb
+++ b/db/migrate/20230501152912_create_promotion_codes.rb
@@ -1,0 +1,11 @@
+class CreatePromotionCodes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :promotion_codes do |t|
+      t.string :code, null: false
+      t.integer :discount, null: false
+      t.boolean :is_used, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230501153401_add_discount_to_orders.rb
+++ b/db/migrate/20230501153401_add_discount_to_orders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDiscountToOrders < ActiveRecord::Migration[7.0]
   def change
     add_column :orders, :discount, :integer

--- a/db/migrate/20230501153401_add_discount_to_orders.rb
+++ b/db/migrate/20230501153401_add_discount_to_orders.rb
@@ -1,0 +1,5 @@
+class AddDiscountToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :discount, :integer
+  end
+end

--- a/db/migrate/20230502000015_add_promotion_code_to_carts.rb
+++ b/db/migrate/20230502000015_add_promotion_code_to_carts.rb
@@ -1,0 +1,5 @@
+class AddPromotionCodeToCarts < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :carts, :promotion_code, foreign_key: true
+  end
+end

--- a/db/migrate/20230502000015_add_promotion_code_to_carts.rb
+++ b/db/migrate/20230502000015_add_promotion_code_to_carts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPromotionCodeToCarts < ActiveRecord::Migration[7.0]
   def change
     add_reference :carts, :promotion_code, foreign_key: true

--- a/db/migrate/20230502034032_add_index_to_promotion_codes.rb
+++ b/db/migrate/20230502034032_add_index_to_promotion_codes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToPromotionCodes < ActiveRecord::Migration[7.0]
+  def change
+    add_index :promotion_codes, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_02_000015) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_02_034032) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,6 +99,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_02_000015) do
     t.boolean "is_used", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_promotion_codes_on_code", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_28_020937) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_02_000015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_020937) do
   create_table "carts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "promotion_code_id"
+    t.index ["promotion_code_id"], name: "index_carts_on_promotion_code_id"
   end
 
   create_table "order_items", force: :cascade do |t|
@@ -80,6 +82,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_020937) do
     t.string "card_cvv", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "discount"
   end
 
   create_table "products", force: :cascade do |t|
@@ -90,9 +93,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_020937) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "promotion_codes", force: :cascade do |t|
+    t.string "code", null: false
+    t.integer "discount", null: false
+    t.boolean "is_used", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "cart_items", "carts"
   add_foreign_key "cart_items", "products"
+  add_foreign_key "carts", "promotion_codes"
   add_foreign_key "order_items", "orders"
 end

--- a/lib/tasks/promotion_code.rake
+++ b/lib/tasks/promotion_code.rake
@@ -1,0 +1,13 @@
+# lib/tasks/promotion_code.rake
+
+namespace :promotion_code do
+  desc "10 promotion codes"
+  task generate: :environment do
+    10.times do
+      code = SecureRandom.alphanumeric(7)
+      discount = rand(100..1000)
+      PromotionCode.create!(code: code, discount: discount)
+    end
+    puts "10 promotion codes generated"
+  end
+end

--- a/lib/tasks/promotion_code.rake
+++ b/lib/tasks/promotion_code.rake
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 # lib/tasks/promotion_code.rake
 
 namespace :promotion_code do
-  desc "10 promotion codes"
+  desc '10 promotion codes'
   task generate: :environment do
     10.times do
       code = SecureRandom.alphanumeric(7)
       discount = rand(100..1000)
       PromotionCode.create!(code: code, discount: discount)
     end
-    puts "10 promotion codes generated"
+    puts '10 promotion codes generated'
   end
 end


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/11_Ruby_on_Rails/001.2_rails%E3%81%A7EC%E3%82%B5%E3%82%A4%E3%83%88%E3%82%92%E4%BD%9C%E3%82%8B.md

## やったこと

* このプルリクで何をしたのか？
- プロモーションテーブルを追加
- カートテーブルにプロモーションIDを追加
- オーダーテーブルにプロモーション割引額を追加
- プロモーションコード処理のコントローラーを追加し、それに関するビューを修正
- 

## 動作確認方法
*Herokuにデプロイしています。　
https://whispering-castle-84062.herokuapp.com/
